### PR TITLE
fix: 로그인 카운트 버그 수정

### DIFF
--- a/src/main/java/github/com/jbabe/config/customEventListener/AuthenticationListener.java
+++ b/src/main/java/github/com/jbabe/config/customEventListener/AuthenticationListener.java
@@ -4,7 +4,9 @@ import github.com.jbabe.config.security.AccountConfig;
 import github.com.jbabe.repository.user.User;
 import github.com.jbabe.service.exception.CustomBadCredentialsException;
 import github.com.jbabe.web.dto.authAccount.AuthFailureMessage;
+import github.com.jbabe.web.dto.authAccount.FailureUserDto;
 import jakarta.annotation.PostConstruct;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
@@ -14,6 +16,7 @@ import org.springframework.security.authentication.event.AuthenticationFailureBa
 import org.springframework.security.authentication.event.AuthenticationSuccessEvent;
 import org.springframework.stereotype.Component;
 
+import java.net.http.HttpRequest;
 import java.time.format.DateTimeFormatter;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -22,18 +25,26 @@ import java.util.Map;
 @RequiredArgsConstructor
 public class AuthenticationListener {
     private final AccountConfig accountConfig;
+    private final HttpServletRequest request;
 
 
     @EventListener
     public void handleBadCredentialsEvent(AuthenticationFailureBadCredentialsEvent event){
-        User user = accountConfig.failureCounting(event.getAuthentication().getName());
+        accountConfig.failureCounting(event.getAuthentication().getName());
+        FailureUserDto failureInfo = FailureUserDto.builder()
+                .name(request.getSession().getAttribute("name").toString())
+                .failureCount((Integer) request.getSession().getAttribute("failCount"))
+                .status(User.UserStatus.valueOf(request.getSession().getAttribute("status").toString()))
+                .failureDate((java.time.LocalDateTime) request.getSession().getAttribute("failureDate"))
+                .withdrawalDate((java.time.LocalDateTime) request.getSession().getAttribute("withdrawalDate"))
+                .build();
 
 
         throw new CustomBadCredentialsException(
-                user.getUserStatus() == User.UserStatus.LOCKED?
+                failureInfo.getStatus() == User.UserStatus.LOCKED?
                         event.getException().getMessage()+" 계정이 잠깁니다."
                         :event.getException().getMessage(),
-                new AuthFailureMessage(user)
+                new AuthFailureMessage(failureInfo)
 
         );
     }

--- a/src/main/java/github/com/jbabe/config/security/AccountConfig.java
+++ b/src/main/java/github/com/jbabe/config/security/AccountConfig.java
@@ -3,8 +3,11 @@ package github.com.jbabe.config.security;
 import github.com.jbabe.repository.user.User;
 import github.com.jbabe.repository.user.UserJpa;
 import github.com.jbabe.service.exception.NotFoundException;
+import github.com.jbabe.web.dto.authAccount.FailureUserDto;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Propagation;
@@ -14,6 +17,8 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class AccountConfig {
     private final UserJpa userJpa;
+    private final HttpServletRequest request;
+
 
     /* 계
      * 정
@@ -30,12 +35,22 @@ public class AccountConfig {
                 new NotFoundException("Not Found User", principal));
     }
 
-//    @Transactional
-    public User failureCounting(String principal) {
+    @Transactional
+    public void failureCounting(String principal) {
         User failUser = userJpa.findByEmail(principal).orElseThrow(()->
                 new NotFoundException("Not Found User", principal));
-        userJpa.updateFailureCount(failUser.loginValueSetting(true));
-        return failUser;
+        failUser.loginValueSetting(true);
+//        userJpa.updateFailureCount(failUser.loginValueSetting(true));
+
+//        return new FailureUserDto(failUser);
+
+        //세션 활용 고민중
+        HttpSession session = request.getSession();
+        session.setAttribute("failCount", failUser.getFailureCount());
+        session.setAttribute("name", failUser.getName()) ;
+        session.setAttribute("status", failUser.getUserStatus().name());
+        session.setAttribute("failureDate", failUser.getLockAt());
+        session.setAttribute("withdrawalDate", failUser.getDeleteAt());
 
 
     }

--- a/src/main/java/github/com/jbabe/repository/user/User.java
+++ b/src/main/java/github/com/jbabe/repository/user/User.java
@@ -152,7 +152,7 @@ public class User {
         return this.failureCount < 4;
     }
 
-    public User loginValueSetting(boolean failure){
+    public void loginValueSetting(boolean failure){
         this.userStatus = failure ?
                 (isFailureCountingOrLocking()||isUnlockTime() ? UserStatus.NORMAL : UserStatus.LOCKED)
                 : UserStatus.NORMAL;
@@ -162,7 +162,7 @@ public class User {
                         : (isFailureCountingOrLocking() ? failureCount + 1 : 0))
                 : 0;
         this.lockAt = failure ? LocalDateTime.now() : null;
-        return this;
+        this.loginAt = failure ? this.loginAt : LocalDateTime.now();
     }
 
     public static LocalDate getBirthByLocalDate(String birth) {

--- a/src/main/java/github/com/jbabe/service/authAccount/LoginCookieService.java
+++ b/src/main/java/github/com/jbabe/service/authAccount/LoginCookieService.java
@@ -69,16 +69,18 @@ public class LoginCookieService {
 
 
 
-    @Transactional
+//    @Transactional
     public AccessAndRefreshToken loginCookie(String email, String password) {
         Authentication authentication = authenticationManager.authenticate(new UsernamePasswordAuthenticationToken(email, password));
 
         try {
-            SecurityContextHolder.getContext().setAuthentication(authentication);
+//            SecurityContextHolder.getContext().setAuthentication(authentication);
             String userEmail = authentication.getName();
-            User user = userJpa.findByEmail(userEmail).orElseThrow(() -> new NotFoundException("유저를 찾을 수 없습니다.", userEmail));
-            user.setLoginAt(LocalDateTime.now());
-            userJpa.save(user);
+
+
+//            User user = userJpa.findByEmail(userEmail).orElseThrow(() -> new NotFoundException("유저를 찾을 수 없습니다.", userEmail));
+//            user.setLoginAt(LocalDateTime.now());
+//            userJpa.save(user);
 
             String accessToken = jwtTokenConfig.createAccessToken(userEmail);
             String refreshToken = jwtTokenConfig.createRefreshToken(userEmail);

--- a/src/main/java/github/com/jbabe/service/userDetails/CustomUserDetailService.java
+++ b/src/main/java/github/com/jbabe/service/userDetails/CustomUserDetailService.java
@@ -5,6 +5,7 @@ import github.com.jbabe.repository.user.UserJpa;
 import github.com.jbabe.service.exception.CustomBadCredentialsException;
 import github.com.jbabe.service.exception.NotFoundException;
 import github.com.jbabe.web.dto.authAccount.AuthFailureMessage;
+import github.com.jbabe.web.dto.authAccount.FailureUserDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Primary;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -43,9 +44,9 @@ public class CustomUserDetailService implements UserDetailsService {
 
     public void checkAccountStatusBeforeLogin(User user){
         if(user.isLocked() && !user.isUnlockTime()){
-            throw new CustomBadCredentialsException("Login Locked User", new AuthFailureMessage(user));
+            throw new CustomBadCredentialsException("Login Locked User", new AuthFailureMessage(new FailureUserDto(user)));
         } else if (user.isDisabled()) {
-            throw  new CustomBadCredentialsException("Disable User", new AuthFailureMessage(user));
+            throw  new CustomBadCredentialsException("Disable User", new AuthFailureMessage(new FailureUserDto(user)));
         }
     }
 

--- a/src/main/java/github/com/jbabe/web/dto/authAccount/AuthFailureMessage.java
+++ b/src/main/java/github/com/jbabe/web/dto/authAccount/AuthFailureMessage.java
@@ -17,11 +17,11 @@ public class AuthFailureMessage {
     @JsonInclude(JsonInclude.Include.NON_NULL)
     private final LocalDateTime withdrawalDate;
 
-    public AuthFailureMessage(User myUser){
+    public AuthFailureMessage(FailureUserDto myUser){
         this.name = myUser.getName();
         this.failureCount = myUser.isDisabled()||myUser.isLocked() ? null:myUser.getFailureCount();
-        this.status = myUser.getUserStatus().name();
-        this.failureDate = myUser.getLockAt();
-        this.withdrawalDate = myUser.getDeleteAt();
+        this.status = myUser.getStatus().name();
+        this.failureDate = myUser.getFailureDate();
+        this.withdrawalDate = myUser.getWithdrawalDate();
     }
 }

--- a/src/main/java/github/com/jbabe/web/dto/authAccount/FailureUserDto.java
+++ b/src/main/java/github/com/jbabe/web/dto/authAccount/FailureUserDto.java
@@ -1,0 +1,34 @@
+package github.com.jbabe.web.dto.authAccount;
+
+import github.com.jbabe.repository.user.User;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class FailureUserDto {
+    private final String name;
+    private final Integer failureCount;
+    private final User.UserStatus status;
+    private final LocalDateTime failureDate;
+    private final LocalDateTime withdrawalDate;
+
+    public FailureUserDto(User user){
+        this.name = user.getName();
+        this.failureCount = user.getFailureCount();
+        this.status = user.getUserStatus();
+        this.failureDate = user.getLockAt();
+        this.withdrawalDate = user.getDeleteAt();
+    }
+
+    public boolean isLocked(){
+        return this.status == User.UserStatus.LOCKED;
+    }
+    public boolean isDisabled(){
+        return this.status == User.UserStatus.HIDE || this.status == User.UserStatus.DELETE;
+    }
+}


### PR DESCRIPTION
#92

/*
영속성컨텍스트 범위 버그로 트랜젝셔널 제거
authenticationManager.authenticate(new UsernamePasswordAuthenticationToken(email, password)) 에서
인증실패시 CustomUserDetailService 에서 발생한 익셉션을 받아 catch문으로 가기 때문에 여기서 유저정보를 조회할 필요는 없음 만약 트랜젝션이 적용되어 있을 경우 적용된 메서드 내에서 로그인 실패시 뜬 익셉션때문에 이벤트리스너에서 엔티티 수정하더라도 롤백됨.

또, 로그인성공시 이벤트리스너를 통해 카운트초기화, 유저상태변경하며 로그인시간정보도 저장하기때문에 여기서 로그인시간을 업데이트 안해도됨. 
해당 로직에서 인증이 완료되면 인증된 객체가 SecurityContextHolder 에 저장되어 있어서 SecurityContextHolder 에  set도 불필요
 */